### PR TITLE
small outlet fix to the category page top margin

### DIFF
--- a/outlet/css/outlet-styles.css
+++ b/outlet/css/outlet-styles.css
@@ -105,7 +105,8 @@
 }
 @media screen and (max-width: 767px){
 .page-header { border-top: 0px solid #333; }
-.main-container { margin-top: 71px !important; }
+.main-container {margin-top: 70px !important;}
+.catalog-category-view .main-container {margin-top: 130px !important;}
 .header-minicart .minicart-wrapper{box-shadow: 0px 0px 50px rgba(0, 0, 0, 0.39); border: solid 1px #c1c1c1;}
 .block-cart.skip-active .minicart-wrapper .block-subtitle .skip-link-close {    display: none;}
 .header-minicart .block-subtitle { color: #606060; font-size: 13px; font-weight: normal; line-height: 1.4; padding: 5px; text-align: center; text-transform: none; margin-bottom: 0px; background: #fff; margin-bottom: 10px; border-bottom: 1px solid #eee; }


### PR DESCRIPTION
Added in a small outlet style to edit the category page top margin, so that cat headings are fully visible on mobiles.