### PR TITLE
removed scroll bar from the d2b alt images

### DIFF
--- a/dare2b/css/dare2b-styles.css
+++ b/dare2b/css/dare2b-styles.css
@@ -977,7 +977,7 @@ dl::-webkit-scrollbar-thumb {
 
 
 .product-view{position:relative}
-div.MagicToolboxSelectorsContainer{position:absolute; left: -94px; top: 0; width: 86px !important; padding: 10px; background: #fff; border: 1px solid #ddd; border-radius: 4px; max-height: 300px; overflow: auto;}
+div.MagicToolboxSelectorsContainer{position:absolute;left: -94px;top: 0;width: 86px !important;padding: 10px;background: #fff;border: 1px solid #ddd;border-radius: 4px;max-height: 300px;overflow: hidden;}
 .mcs-item > a, .MagicScroll-horizontal .mcs-items-container{}
 .mcs-item > a, .MagicScroll-horizontal .mcs-items-container > .mcs-item{float: none; display: block;}
 .mcs-items-container{transform: none !important}


### PR DESCRIPTION
Changed the overflow from 'auto' to 'hidden' for the D2B alt image container, to hide the scroll bar 🕹 