### PR TITLE
fixed a mobile issue where the product title was too big on small mob…

### DIFF
--- a/outlet/css/outlet-styles.css
+++ b/outlet/css/outlet-styles.css
@@ -145,6 +145,7 @@
   .catalog-product-view .percentOffContainer {    padding: 10px 10px;}
   .prod-size-chart { left: 0px; right: 0; }
   .category-products .limiter {    margin-top: 0px;}
+  .product-view .product-shop .product-name .h1 { font-size: 20px !important; }
 }
 
 


### PR DESCRIPTION
…ile devices  

Long product titles was pushing the price box section under product image.